### PR TITLE
Clean up source formatting.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ sdist: clean
 	python setup.py sdist
 	mv -f dist/*.tar.gz .
 
+format:
+	@ echo "Formatting Python source files ..."
+	find . -type f -name '*.py' -print0 | \
+		xargs -0 yapf --style=pep8 -i
+
 clean:
 	rm -f MANIFEST
 	rm -vfr build

--- a/scrub.py
+++ b/scrub.py
@@ -18,12 +18,13 @@ except ImportError:
 def usage(opts):
     print("Usage: scrub.py [options] <url>", file=sys.stderr)
     if opts:
-        print("\nOptions:\n"
-              "  -e/--encoding <enc>  : specify input encoding.\n"
-              "  -h/--html            : treat input as HTML.\n"
-              "  -s/--skipwhite       : skip whitespace text runs.\n"
-              "  --help               : print this help message.\n",
-              file=sys.stdout)
+        print(
+            "\nOptions:\n"
+            "  -e/--encoding <enc>  : specify input encoding.\n"
+            "  -h/--html            : treat input as HTML.\n"
+            "  -s/--skipwhite       : skip whitespace text runs.\n"
+            "  --help               : print this help message.\n",
+            file=sys.stdout)
         return 0
     else:
         print("  [use --help for a summary of options]", file=sys.stderr)

--- a/scrubbyex.py
+++ b/scrubbyex.py
@@ -13,13 +13,7 @@ from __future__ import print_function
 import scrubby
 import os, re, sys
 
-# For compatibility with Python 2 and 3.
-try:
-    import urllib.request as urllib
-except ImportError:
-    import urllib
-
-# {{ Utility functions
+import urllib.request as urllib
 
 # These are some utility functions that are used by the examples further along
 # in this file.
@@ -36,6 +30,7 @@ def load_url(url):
 
 def untabify(text, width):
     """Replace tabs with spaces in text."""
+
     def next_stop(p):
         return width * ((p + width) // width)
 
@@ -76,8 +71,6 @@ def format_snippet(obj, prefix='', span=False, **opts):
     mark = prefix + lead
     return (prefix + line + '\n' + mark)
 
-
-# }}
 
 # This variable is global so that you can inspect the guts of the parser after
 # one of the demo functions has set it up.
@@ -133,12 +126,6 @@ def report_missing_alts(url):
     print("<done>")
 
 
-# }}
-
-# {{ report_unclosed_paras(url)
-
-
-#<>
 def report_unclosed_paras(url):
     """<> Generate a report of any <p> tags that are not balanced by a
     corresponding </p> in an HTML document.
@@ -196,11 +183,6 @@ def report_unclosed_paras(url):
     print("<done>")
 
 
-# }}
-
-# {{ report_explicit_styles(url)
-
-
 def report_explicit_styles(url):
     """<> Generate a report of any non-SPAN tags that have a non-empty explicit
     style attribute.  This can catch things which probably should have been put
@@ -242,11 +224,6 @@ def report_explicit_styles(url):
                      p['style'], prefix='| ', span=True, width=80, tabsize=8)))
 
     print("<done>")
-
-
-# }}
-
-# {{ fetch_latest_comic()
 
 
 def fetch_latest_comic():
@@ -302,7 +279,5 @@ def fetch_latest_comic():
 
     print("<done>")
 
-
-# }}
 
 # Here there be dragons.

--- a/test_scrubby.py
+++ b/test_scrubby.py
@@ -15,6 +15,7 @@ class test_scanner(unittest.TestCase):
     methods; higher-level methods should be tested by using the results in a
     markup_parser.
     """
+
     def test_empty_input(self):
         """Test correct scan of empty input."""
         ts = list(S.markup_scanner('').scan())
@@ -143,6 +144,7 @@ class test_scanner(unittest.TestCase):
 
 class test_parser(unittest.TestCase):
     """Unit tests for markup_parser."""
+
     def test_directive(self):
         """Test markup directives."""
         s = S.markup_parser('<!DOCTYPE html public>')
@@ -228,6 +230,7 @@ class test_parser(unittest.TestCase):
 
     def test_custom_nesting(self):
         """Test some simple customized nesting rules."""
+
         class TP(S.markup_parser):
             CLOSED_BY_CLOSE = {'c': set(('b', ))}
             CLOSED_BY_OPEN = {'c': set(('c', ))}
@@ -435,6 +438,7 @@ class test_parser(unittest.TestCase):
 
 class test_html(test_parser):
     """Unit tests for html_parser."""
+
     def test_html_nesting(self):
         """Test HTML nesting rules."""
         s = S.html_parser('<html><head> a <body> b </html>')


### PR DESCRIPTION
- Remove compatibility definitions for Python 2.
- Remove folding-mode comments.
- Add a source formatting rule to Makefile.
- Format source with yapf (PEP8).